### PR TITLE
Added support for JS-Only loader (fragment)

### DIFF
--- a/lib/iconizr.js
+++ b/lib/iconizr.js
@@ -539,26 +539,48 @@ Iconizr.prototype._renderLoaderFragment = function(callback) {
 			console.log('Creating the stylesheet loader fragment ...');
 		}
 		
+		this._options.loader 								= this._options.loader || {};
+
 		try {
 			var that								= this,
-			dest									= path.join(this._options.outputDir, this.css + '-loader-fragment.html'),
-			embed									= path.normalize(this._options.embed),
+			type 									= this._options.loader.type || 'html',
+			loaderDir 								= path.resolve(this._options.outputDir, (this._options.loader.dest || '')),
+			dest 									= path.join(loaderDir, this.css + '-loader-fragment.' + type),
 			data									= {
 				'png-sprite'						: this.css + '-png-sprite.css',
 				'png-data'							: this.css + '-png-data.css',
 				'svg-sprite'						: this.css + '-svg-sprite.css',
 				'svg-data'							: this.css + '-svg-data.css'
 			},
+			html,
+			embed,
+			loader,
 			script									= mustache.render(fs.readFileSync(path.join(path.dirname(__dirname), 'tmpl', 'loader.js'), 'utf-8'), data);
-			embed									= (!embed || (embed == '.')) ? '' : (embed + '/');
-			data.script								= UglifyJS.minify(script, {fromString: true}).code;
-			script									= mustache.render(fs.readFileSync(path.join(path.dirname(__dirname), 'tmpl', 'loader.html'), 'utf-8'), data).split('##embed##').join(embed);
-			if (script.length) {
-				fs.writeFileSync(dest, script);
-				that.result.files[dest]				= script.length;
-				++that.result.length;
+
+			if (this._options.loader.minify === undefined || !!this._options.loader.minify) {
+				script								= UglifyJS.minify(script, {fromString: true}).code;
 			}
-			callback(null, script);
+
+			if (type === 'js') {
+				if (script.length) {
+					fs.writeFileSync(dest, script);
+					that.result.files[dest]       = script.length;
+					++that.result.length;
+				}
+				loader = script;
+			} else { // html
+				embed								= path.normalize(this._options.embed);
+				embed								= (!embed || (embed == '.')) ? '' : (embed + '/');
+				data.script							= script;
+				html 								= mustache.render(fs.readFileSync(path.join(path.dirname(__dirname), 'tmpl', 'loader.html'), 'utf-8'), data).split('##embed##').join(embed);
+				if (html.length) {
+					fs.writeFileSync(dest, html);
+					that.result.files[dest]		= html.length;
+					++that.result.length;
+				}
+				loader = html;
+			}
+			callback(null, loader);
 
 		} catch(e) {
 			callback(e, null);

--- a/lib/iconizr.js
+++ b/lib/iconizr.js
@@ -553,9 +553,11 @@ Iconizr.prototype._renderLoaderFragment = function(callback) {
 				'svg-data'							: this.css + '-svg-data.css'
 			},
 			html,
-			embed,
+			embed									= path.normalize(this._options.embed),
 			loader,
 			script									= mustache.render(fs.readFileSync(path.join(path.dirname(__dirname), 'tmpl', 'loader.js'), 'utf-8'), data);
+			script 									= script.split('##embed##').join(embed);
+			embed									= (!embed || (embed == '.')) ? '' : (embed + '/');
 
 			if (this._options.loader.minify === undefined || !!this._options.loader.minify) {
 				script								= UglifyJS.minify(script, {fromString: true}).code;
@@ -569,8 +571,6 @@ Iconizr.prototype._renderLoaderFragment = function(callback) {
 				}
 				loader = script;
 			} else { // html
-				embed								= path.normalize(this._options.embed);
-				embed								= (!embed || (embed == '.')) ? '' : (embed + '/');
 				data.script							= script;
 				html 								= mustache.render(fs.readFileSync(path.join(path.dirname(__dirname), 'tmpl', 'loader.html'), 'utf-8'), data).split('##embed##').join(embed);
 				if (html.length) {


### PR DESCRIPTION
Hi, thanks for this nice library and here is my proposal for an enhancement: 

**Reasons for the Update**:
 - I needed to generate a JS file instead of the HTML loader fragment file.
 - I needed the generated file to be placed in a custom directory rather than the default.
 - I needed the javascript source code to be raw (not uglified)
 - I needed all of these to be configurable so I can default back to generating HTML fragments when necessary.

I've altered the `Iconizr.prototype._renderLoaderFragment` method, so that it enables the following changes/features without disabling any existing ones or default behaviours. So, if the following configurations/options are not set at all, **iconizr** will just behave the expected way.

**Changes**:
 - Added `options.loader`
   - `options.loader.type` (String) Valid values: `"html"` or `"js"`. Default: `"html"`  
  Specifies the type of loader file to generate. Set to `.html` if `<noscript>` fallback is required.
   - `options.loader.minify` (Boolean) Default: `true`  
  Specifies whether to minify the JS loader code.
   - `options.loader.dest` (String) Default: `""` (empty)  
  Indicates the directory for the generated loader file (relative to the output directory).

I couldn’t see any contributing guidelines but, still tried to keep up with your coding style (tabs, indents, etc)... Also tested with `grunt-iconizr`.

Note: I might optimize this further (also update the readme) once accepted.

Best,
Onur Y.